### PR TITLE
Fix: 네이버/애플 로그인 버튼 아이콘 표시 오류 수정

### DIFF
--- a/style.css
+++ b/style.css
@@ -117,8 +117,9 @@ h2 {
     border-color: #03C75A;
 }
 .social-button.naver img {
-    width: auto; /* 네이버 로고는 비율 유지를 위해 auto로 설정 */
-    height: 18px; /* 높이 조정 */
+    width: 18px; /* 너비 고정 */
+    height: 18px; /* 높이 고정 */
+    object-fit: contain; /* 비율 유지하며 채우기 */
 }
 
 
@@ -138,8 +139,9 @@ h2 {
 
 .social-button.apple img {
     filter: invert(1); /* 애플 로고가 검은색 배경에 잘 보이도록 색상 반전 */
-    width: auto;
-    height: 20px; /* 높이 조정 */
+    width: 20px; /* 너비 고정 */
+    height: 20px; /* 높이 고정 */
+    object-fit: contain; /* 비율 유지하며 채우기 */
 }
 
 


### PR DESCRIPTION
- `style.css`에서 네이버 및 애플 로그인 버튼 아이콘의 너비를 명시적으로 지정하고 `object-fit: contain` 속성을 추가하여 아이콘이 겹치거나 레이아웃을 벗어나는 문제 해결.